### PR TITLE
Restart Command

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -34,5 +34,7 @@
 		"kill-no-weapon": [
 			"`{attacker}` killed `{victim}`"
 		]
-	}
+	},
+
+	"restart-command": "echo 'change restart-command in your config.json' > changeme.txt"
 }

--- a/src/config.py
+++ b/src/config.py
@@ -24,3 +24,4 @@ class Config:
 	timeDownBeforeNotify: float = 8080
 	relayPort: int = 8080
 	messageFormats: MessageFormats = MessageFormats()
+	restartCommand: str = "echo 'change restart-command in your config.json' > changeme.txt"


### PR DESCRIPTION
**Related Issue Link (if applicable)**  
*issue no. here*  

#### Changes  
Adds a field to the Config class that lets you change the command that is executed when someone runs !restart

#### Fixes  
Privilaged users are now able to restart the server without needing to ssh into the box or do any other funky shit

#### Additions  
Adds a command that lets privileged users restart the gmod server without needing to SSH into the server box or any other funky shit.